### PR TITLE
Start using sage-package to factor out common stuff

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,14 +45,12 @@ sys.path.append(os.path.join(SAGE_SRC, "sage_setup", "docbuild", "ext"))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
+extensions = [ # Maybe some more of this could be moved to sage-package
     #'sphinx.ext.autodoc',
     'sage_autodoc',
     'sphinx.ext.doctest',
-    'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.extlinks',
+    'sage_package.sphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -117,34 +115,22 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
-pythonversion = sys.version.split(' ')[0]
-# Python and Sage trac ticket shortcuts. For example, :trac:`7549` .
-extlinks = {
-    'python': ('https://docs.python.org/release/'+pythonversion+'/%s', ''),
-    'trac': ('http://trac.sagemath.org/%s', 'trac ticket #'),
-    'wikipedia': ('https://en.wikipedia.org/wiki/%s', 'Wikipedia article '),
-    'arxiv': ('http://arxiv.org/abs/%s', 'Arxiv '),
-    'oeis': ('https://oeis.org/%s', 'OEIS sequence '),
-    'doi': ('https://dx.doi.org/%s', 'doi:'),
-    'mathscinet': ('http://www.ams.org/mathscinet-getitem?mr=%s', 'MathSciNet ')
-    }
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+# html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {}
+# html_theme_options = {}
 
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
 #html_theme_path = [os.path.join(SAGE_DOC_SRC, 'common', 'themes')]
-html_theme_path = [os.path.join(SAGE_DOC_SRC, 'common', 'themes', 'sage')]
+#html_theme_path = [os.path.join(SAGE_DOC_SRC, 'common', 'themes', 'sage')]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,12 +4,13 @@ Sage Sample Package
 
 This is a sample reference manual for a SageMath package.
 
-To use this module, you need to import it:: 
+To use this module, you need to import it::
 
     from sage_sample import *
 
 This reference shows a minimal example of documentation of the
-Sage sample package following SageMath guidelines.
+Sage sample package following
+:ref:`SageMath guidelines <chapter-code-basics>`.
 
 This work is licensed under a `Creative Commons Attribution-Share Alike
 3.0 License`__.

--- a/setup.py
+++ b/setup.py
@@ -3,20 +3,11 @@ import os
 import sys
 from setuptools import setup
 from codecs import open # To open the README file with proper encoding
-from setuptools.command.test import test as TestCommand # for tests
-
 
 # Get information from separate files (README, VERSION)
 def readfile(filename):
     with open(filename,  encoding='utf-8') as f:
         return f.read()
-
-# For the tests
-class SageTest(TestCommand):
-    def run_tests(self):
-        errno = os.system("sage -t --force-lib sage_sample")
-        if errno != 0:
-            sys.exit(1)
 
 setup(
     name = "sage_sample",
@@ -41,5 +32,11 @@ setup(
     ], # classifiers list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
     keywords = "SageMath packaging",
     packages = ['sage_sample'],
-    cmdclass = {'test': SageTest} # adding a special setup command for tests
+    setup_requires   = ['sage-package'],
+    install_requires = ['sage-package', 'sphinx'],
+    entry_points = {
+        "distutils.commands": [
+            "test = sage_package.setuptools:SageTest",
+        ],
+    }
 )


### PR DESCRIPTION
This adds a dependency. But is a step toward reducing the boilerplate in our packages by factoring it out in a [single package](https://github.com/sagemath/sage-package). This also makes it easier to enhance that boilerplate to add new features (e.g. improvements to the Sphinx theme, which could include live doc support).

What do you think?