### PR TITLE
Correct make uninstall

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ install:
 	$(SAGE) -pip install --upgrade --no-index -v .
 
 uninstall:
-	$(SAGE) -pip uninstall .
+	$(SAGE) -pip uninstall $(PACKAGE)
 
 develop:
 	$(SAGE) -pip install --upgrade -e .


### PR DESCRIPTION
`pip uninstall` requires a package name as argument, hence `sage -pip uninstall .` is not valid.
See [this discussion](https://github.com/sagemath/sage_sample/issues/31).